### PR TITLE
feat: Add voice selection for text-to-speech

### DIFF
--- a/magic-8-ball/package-lock.json
+++ b/magic-8-ball/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^6.1.1",
         "@tsconfig/svelte": "^5.0.4",
+        "@types/dom-speech-recognition": "^0.0.6",
         "@types/node": "^24.3.0",
         "autoprefixer": "^10.4.21",
         "svelte": "^5.38.1",
@@ -1149,6 +1150,13 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.5.tgz",
       "integrity": "sha512-48fAnUjKye38FvMiNOj0J9I/4XlQQiZlpe9xaNPfe8vy2Y1hFBt8g1yqf2EGjVvHavo4jf2lC+TQyENCr4BJBQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/dom-speech-recognition": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/dom-speech-recognition/-/dom-speech-recognition-0.0.6.tgz",
+      "integrity": "sha512-o7pAVq9UQPJL5RDjO1f/fcpfFHdgiMnR4PoIU2N/ZQrYOS3C5rzdOJMsrpqeBCbii2EE9mERXgqspQqPDdPahw==",
       "dev": true,
       "license": "MIT"
     },

--- a/magic-8-ball/package.json
+++ b/magic-8-ball/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^6.1.1",
     "@tsconfig/svelte": "^5.0.4",
+    "@types/dom-speech-recognition": "^0.0.6",
     "@types/node": "^24.3.0",
     "autoprefixer": "^10.4.21",
     "svelte": "^5.38.1",

--- a/magic-8-ball/src/App.svelte
+++ b/magic-8-ball/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { textToSpeech } from './lib/stores';
+  import { textToSpeech, selectedVoice } from './lib/stores';
   import Settings from './lib/Settings.svelte';
 
   let question = "";
@@ -46,7 +46,11 @@
 
     if ($textToSpeech) {
       const utterance = new SpeechSynthesisUtterance(answer);
-      utterance.lang = 'en-US';
+      const voices = speechSynthesis.getVoices();
+      const voice = voices.find(v => v.voiceURI === $selectedVoice);
+      if (voice) {
+        utterance.voice = voice;
+      }
       speechSynthesis.speak(utterance);
     }
   }

--- a/magic-8-ball/src/lib/Settings.svelte
+++ b/magic-8-ball/src/lib/Settings.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { shakeDetection, textToSpeech } from './stores';
+  import { shakeDetection, textToSpeech, selectedVoice } from './stores';
 
   let motionPermissionGranted = false;
   let needsMotionPermission = false;
+  let voices: SpeechSynthesisVoice[] = [];
 
   function setupShakeDetection() {
     let lastX: number, lastY: number, lastZ: number;
@@ -77,6 +78,15 @@
         setupShakeDetection();
       }
     });
+
+    function populateVoiceList() {
+      voices = speechSynthesis.getVoices();
+    }
+
+    populateVoiceList();
+    if (speechSynthesis.onvoiceschanged !== undefined) {
+      speechSynthesis.onvoiceschanged = populateVoiceList;
+    }
   });
 
   function handleShakeDetectionChange(event: Event) {
@@ -87,6 +97,11 @@
   function handleTextToSpeechChange(event: Event) {
     const target = event.target as HTMLInputElement;
     textToSpeech.set(target.checked);
+  }
+
+  function handleVoiceChange(event: Event) {
+    const target = event.target as HTMLSelectElement;
+    selectedVoice.set(target.value);
   }
 </script>
 
@@ -116,6 +131,27 @@
             <input type="checkbox" name="setting" aria-label="Enable Text-to-Speech" class="absolute inset-0 appearance-none focus:outline-hidden" on:change={handleTextToSpeechChange} checked={$textToSpeech} />
           </div>
         </div>
+        {#if $textToSpeech}
+        <div>
+          <label for="voice-select" class="block text-sm/6 font-medium text-gray-900 dark:text-white">Choose a voice</label>
+          <div class="mt-2 grid grid-cols-1">
+            <select
+              id="voice-select"
+              name="voice-select"
+              class="col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-1.5 pr-8 pl-3 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:*:bg-gray-800 dark:focus-visible:outline-indigo-500"
+              on:change={handleVoiceChange}
+              bind:value={$selectedVoice}
+            >
+              {#each voices as voice}
+                <option value={voice.voiceURI}>{voice.name} ({voice.lang})</option>
+              {/each}
+            </select>
+            <svg viewBox="0 0 16 16" fill="currentColor" data-slot="icon" aria-hidden="true" class="pointer-events-none col-start-1 row-start-1 mr-2 size-5 self-center justify-self-end text-gray-500 sm:size-4 dark:text-gray-400">
+              <path d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" fill-rule="evenodd" />
+            </svg>
+          </div>
+        </div>
+        {/if}
       </div>
     </div>
   </el-popover>

--- a/magic-8-ball/src/lib/stores.ts
+++ b/magic-8-ball/src/lib/stores.ts
@@ -2,3 +2,4 @@ import { writable } from 'svelte/store';
 
 export const shakeDetection = writable(false);
 export const textToSpeech = writable(false);
+export const selectedVoice = writable<string | null>(null);


### PR DESCRIPTION
This feature adds a dropdown menu to the settings panel, allowing users to select a specific voice for the text-to-speech feature from the available voices on their device.

- A new Svelte store, `selectedVoice`, is created to store the URI of the selected voice.
- The `Settings.svelte` component is updated to fetch and display the list of available voices in a dropdown menu when text-to-speech is enabled.
- The `App.svelte` component is modified to use the selected voice for the `SpeechSynthesisUtterance`.
- The redundant `utterance.lang` property is removed from `App.svelte` as the voice object itself contains the language information.
- Pre-existing TypeScript errors related to SpeechRecognition have been fixed by adding the `@types/dom-speech-recognition` dev dependency.